### PR TITLE
Add labels bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "email": "nuno@seegno.com",
     "url": "https://seegno.com"
   },
+  "main": "./dist/index.js",
   "bin": {
     "ghlabels": "./dist/bin/labels.js"
   },
@@ -26,6 +27,9 @@
     "test-watch": "jest --watch --notify --onlyChanged",
     "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "dependencies": {
     "bluebird": "^3.3.1",
     "config": "^1.19.0",
@@ -61,8 +65,5 @@
     ],
     "testEnvironment": "node",
     "testRegex": "(/test/.*\\.test.js)$"
-  },
-  "pre-commit": [
-    "lint"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "email": "nuno@seegno.com",
     "url": "https://seegno.com"
   },
-  "bin": "./dist/index.js",
+  "bin": {
+    "ghlabels": "./dist/bin/labels.js"
+  },
   "scripts": {
     "build": "rm -rf dist/* && babel src --out-dir dist",
     "changelog": "github_changelog_generator --no-issues --header-label='# Changelog' --future-release=v$npm_config_future_release && sed -i '' -e :a -e '$d;N;2,4ba' -e 'P;D' CHANGELOG.md",

--- a/src/bin/labels.js
+++ b/src/bin/labels.js
@@ -1,0 +1,78 @@
+#! /usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+import { get, keys, omit, pickBy, values } from 'lodash';
+import { readFile } from 'fs';
+import { version } from '../../package.json';
+import Promise from 'bluebird';
+import inquirer from 'inquirer';
+import prettyjson from 'prettyjson';
+import updateLabels from '../';
+import yargs from 'yargs';
+
+/**
+ * Promisify fs readFile method.
+ */
+
+const readFileAsync = Promise.promisify(readFile);
+
+/**
+ * Program options.
+ */
+
+const args = yargs
+  .usage('Usage: $0 [options]')
+  .env('GITHUB_LABELS')
+  .option('owner', { demand: false, describe: 'Repository owner', type: 'string' })
+  .option('repo', { demand: false, describe: 'Repository name', type: 'string' })
+  .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
+  .option('configFile', { demand: false, describe: 'Configuration file', type: 'string' })
+  .help('h')
+  .alias('h', 'help')
+  .version('version', 'Version', version)
+  .alias('V', 'version')
+  .example('$0 --owner foo --repo bar --token foobar --configFile ./path/somefile')
+  .wrap(null)
+  .argv;
+
+/**
+ * Program questions.
+ */
+
+const questions = {
+  configFile: {
+    message: 'What is the configuration file path?',
+    name: 'configFile',
+    validate: input => !!input
+  },
+  owner: {
+    message: 'What is the owner name?',
+    name: 'owner',
+    validate: input => !!input
+  },
+  repo: {
+    message: 'What is the repository name?',
+    name: 'repo',
+    validate: input => !!input
+  }
+};
+
+/**
+ * Program.
+ */
+
+(async function() {
+  const answers = await inquirer.prompt(values(omit(questions, keys(pickBy(args)))));
+  const options = { ...args, ...answers };
+
+  // Retrieve labels from file.
+  const content = await readFileAsync(get(options, 'configFile'), 'utf8');
+  const labels = JSON.parse(content);
+
+  await updateLabels({ ...options, labels });
+
+  return console.log(prettyjson.render(labels)); // eslint-disable-line no-console
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -1,88 +1,23 @@
-#! /usr/bin/env node
 
 /**
  * Module dependencies.
  */
 
-import { keys, omit, pickBy, values } from 'lodash';
-import { readFile } from 'fs';
-import { version } from '../package.json';
 import Client from './client';
-import Promise from 'bluebird';
-import inquirer from 'inquirer';
-import prettyjson from 'prettyjson';
-import yargs from 'yargs';
 
 /**
- * Promisify fs readFile method.
+ * Export application.
  */
 
-const readFileAsync = Promise.promisify(readFile);
-
-/**
- * Program options.
- */
-
-const args = yargs
-  .usage('Usage: $0 [options]')
-  .env('GITHUB_LABELS')
-  .option('owner', { demand: false, describe: 'Repository owner', type: 'string' })
-  .option('repo', { demand: false, describe: 'Repository name', type: 'string' })
-  .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
-  .option('configFile', { demand: false, describe: 'Configuration file', type: 'string' })
-  .help('h')
-  .alias('h', 'help')
-  .version('version', 'Version', version)
-  .alias('V', 'version')
-  .example('$0 --owner foo --repo bar --token foobar --configFile ./path/somefile')
-  .wrap(null)
-  .argv;
-
-/**
- * Program questions.
- */
-
-const questions = {
-  configFile: {
-    message: 'What is the configuration file path?',
-    name: 'configFile',
-    validate: input => !!input
-  },
-  owner: {
-    message: 'What is the owner name?',
-    name: 'owner',
-    validate: input => !!input
-  },
-  repo: {
-    message: 'What is the repository name?',
-    name: 'repo',
-    validate: input => !!input
-  }
-};
-
-/**
- * Program.
- */
-
-(async function() {
-  const answers = await inquirer.prompt(values(omit(questions, keys(pickBy(args)))));
-  const { configFile, owner, repo, token } = { ...args, ...answers };
+export default async options => {
+  const { owner, repo, token, labels } = options;
 
   // Instantiate client.
-  const client = new Client({
-    owner,
-    repo
-  });
+  const client = new Client({ owner, repo });
 
-  // Authenticate user with given `token` in the program options.
+  // Authenticate user.
   client.authenticate(token);
-
-  // Retrieve labels from file.
-  const content = await readFileAsync(configFile, 'utf8');
-  const labels = JSON.parse(content);
 
   // Update the repository labels using the labels in the configuration file.
   await client.updateLabels(labels);
-
-  return console.log(prettyjson.render(labels)); // eslint-disable-line no-console
-})();
+};


### PR DESCRIPTION
This PR adds the labels bin which is the script that is copied to npm bin when installing the package. It was also necessary to update the main application entry point to allow the package to be imported as a module. When sorting the package.json the `pre-commit` property was also moved.