### PR TITLE
Add copy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "inquirer": "^3.0.6",
     "lodash": "^4.3.0",
     "prettyjson": "^1.1.3",
-    "yargs": "^4.2.0"
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-seegno": "^9.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-jest": "^19.0.1",
+    "faker": "^4.1.0",
     "jest": "^20.0.4",
     "standard-http-error": "^2.0.0"
   },

--- a/src/bin/labels.js
+++ b/src/bin/labels.js
@@ -4,75 +4,23 @@
  * Module dependencies.
  */
 
-import { get, keys, omit, pickBy, values } from 'lodash';
-import { readFile } from 'fs';
+import { copyFromRepo, copyFromRepoConfig } from '../commands/copy-from-repo-command';
+import { update, updateConfig } from '../commands/update-command';
 import { version } from '../../package.json';
-import Promise from 'bluebird';
-import inquirer from 'inquirer';
-import prettyjson from 'prettyjson';
-import updateLabels from '../';
 import yargs from 'yargs';
-
-/**
- * Promisify fs readFile method.
- */
-
-const readFileAsync = Promise.promisify(readFile);
 
 /**
  * Program options.
  */
 
-const args = yargs
+yargs // eslint-disable-line no-unused-expressions
   .usage('Usage: $0 [options]')
   .env('GITHUB_LABELS')
-  .option('owner', { demand: false, describe: 'Repository owner', type: 'string' })
-  .option('repo', { demand: false, describe: 'Repository name', type: 'string' })
-  .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
-  .option('configFile', { demand: false, describe: 'Configuration file', type: 'string' })
+  .command(['*', 'update'], 'Update repository labels', updateConfig, update)
+  .command('copy', 'Copy labels from repository', copyFromRepoConfig, copyFromRepo)
   .help('h')
   .alias('h', 'help')
   .version('version', 'Version', version)
   .alias('V', 'version')
-  .example('$0 --owner foo --repo bar --token foobar --configFile ./path/somefile')
   .wrap(null)
   .argv;
-
-/**
- * Program questions.
- */
-
-const questions = {
-  configFile: {
-    message: 'What is the configuration file path?',
-    name: 'configFile',
-    validate: input => !!input
-  },
-  owner: {
-    message: 'What is the owner name?',
-    name: 'owner',
-    validate: input => !!input
-  },
-  repo: {
-    message: 'What is the repository name?',
-    name: 'repo',
-    validate: input => !!input
-  }
-};
-
-/**
- * Program.
- */
-
-(async function() {
-  const answers = await inquirer.prompt(values(omit(questions, keys(pickBy(args)))));
-  const options = { ...args, ...answers };
-
-  // Retrieve labels from file.
-  const content = await readFileAsync(get(options, 'configFile'), 'utf8');
-  const labels = JSON.parse(content);
-
-  await updateLabels({ ...options, labels });
-
-  return console.log(prettyjson.render(labels)); // eslint-disable-line no-console
-})();

--- a/src/client.js
+++ b/src/client.js
@@ -133,10 +133,10 @@ export default class Client {
   }
 
   /**
-   * Update labels.
+   * Set labels.
    */
 
-  async updateLabels(labels) {
+  async setLabels(labels) {
     const current = await this.getLabels();
 
     // Delete current labels that are not included in the wanted labels.

--- a/src/commands/copy-from-repo-command.js
+++ b/src/commands/copy-from-repo-command.js
@@ -1,0 +1,67 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { copyLabelsFromRepo } from '../';
+import { keys, omit, pick, pickBy, values } from 'lodash';
+import inquirer from 'inquirer';
+import prettyjson from 'prettyjson';
+
+/**
+ * Export `copyFromRepoConfig`.
+ */
+
+export function copyFromRepoConfig(yargs) {
+  yargs
+    .option('sourceOwner', { demand: false, describe: 'Source repository owner', type: 'string' })
+    .option('sourceRepo', { demand: false, describe: 'Source repository name', type: 'string' })
+    .option('targetOwner', { demand: false, describe: 'Target repository owner', type: 'string' })
+    .option('targetRepo', { demand: false, describe: 'Target repository name', type: 'string' })
+    .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
+    .example('$0 --owner foo --repo bar --sourceOwner qux --sourceRepo corge --token foobar');
+}
+
+/**
+ * Copy command.
+ */
+
+export async function copyFromRepo(args) {
+  const questions = {
+    sourceOwner: {
+      message: 'What is the source owner name?',
+      name: 'sourceOwner',
+      validate: input => !!input
+    },
+    sourceRepo: {
+      message: 'What is the source repository name?',
+      name: 'sourceRepo',
+      validate: input => !!input
+    },
+    targetOwner: {
+      message: 'What is the target owner name?',
+      name: 'owner',
+      validate: input => !!input
+    },
+    targetRepo: {
+      message: 'What is the target repository name?',
+      name: 'repo',
+      validate: input => !!input
+    },
+    token: {
+      message: 'Provide a GitHub access token',
+      name: 'token',
+      validate: input => !!input
+    }
+  };
+
+  const answers = await inquirer.prompt(values(omit(questions, keys(pickBy(args)))));
+  const options = { ...args, ...answers };
+
+  console.log('Copying labels from repo...'); // eslint-disable-line no-console
+  console.log(prettyjson.render(pick(options, keys(pickBy(questions))))); // eslint-disable-line no-console
+
+  await copyLabelsFromRepo(options);
+
+  return console.log('Copy completed!'); // eslint-disable-line no-console
+}

--- a/src/commands/update-command.js
+++ b/src/commands/update-command.js
@@ -1,0 +1,73 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { get, keys, omit, pick, pickBy, values } from 'lodash';
+import { readFile } from 'fs';
+import { updateLabels } from '../';
+import Promise from 'bluebird';
+import inquirer from 'inquirer';
+import prettyjson from 'prettyjson';
+
+/**
+ * Promisify fs readFile method.
+ */
+
+const readFileAsync = Promise.promisify(readFile);
+
+/**
+ * Export `updateConfig`.
+ */
+
+export function updateConfig(yargs) {
+  yargs
+    .option('configFile', { demand: false, describe: 'Configuration file', type: 'string' })
+    .option('owner', { demand: false, describe: 'Repository owner', type: 'string' })
+    .option('repo', { demand: false, describe: 'Repository name', type: 'string' })
+    .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
+    .example('$0 --owner foo --repo bar --token foobar --configFile ./path/somefile');
+}
+
+/**
+ * Update command.
+ */
+
+export async function update(args) {
+  const questions = {
+    configFile: {
+      message: 'What is the configuration file path?',
+      name: 'configFile',
+      validate: input => !!input
+    },
+    owner: {
+      message: 'What is the owner name?',
+      name: 'owner',
+      validate: input => !!input
+    },
+    repo: {
+      message: 'What is the repository name?',
+      name: 'repo',
+      validate: input => !!input
+    },
+    token: {
+      message: 'Provide a GitHub access token',
+      name: 'token',
+      validate: input => !!input
+    }
+  };
+
+  const answers = await inquirer.prompt(values(omit(questions, keys(pickBy(args)))));
+  const options = { ...args, ...answers };
+
+  console.log('Updating labels...'); // eslint-disable-line no-console
+  console.log(prettyjson.render(pick(options, keys(pickBy(questions))))); // eslint-disable-line no-console
+
+  // Retrieve labels from file.
+  const content = await readFileAsync(get(options, 'configFile'), 'utf8');
+  const labels = JSON.parse(content);
+
+  await updateLabels({ ...options, labels });
+
+  return console.log('Update completed!'); // eslint-disable-line no-console
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,10 @@
 import Client from './client';
 
 /**
- * Export application.
+ * Export `updateLabels`.
  */
 
-export default async options => {
+export async function updateLabels(options) {
   const { owner, repo, token, labels } = options;
 
   // Instantiate client.
@@ -18,6 +18,31 @@ export default async options => {
   // Authenticate user.
   client.authenticate(token);
 
-  // Update the repository labels using the labels in the configuration file.
-  await client.updateLabels(labels);
-};
+  // Set the repository labels using the labels in the configuration file.
+  await client.setLabels(labels);
+}
+
+/**
+ * Export `copyLabelsFromRepo`.
+ */
+
+export async function copyLabelsFromRepo(options) {
+  const { sourceOwner, sourceRepo, targetOwner, targetRepo, token } = options;
+
+  // Instantiate clients.
+  const clientSource = new Client({ owner: sourceOwner, repo: sourceRepo });
+  const clientTarget = new Client({ owner: targetOwner, repo: targetRepo });
+
+  // Authenticate user.
+  clientSource.authenticate(token);
+  clientTarget.authenticate(token);
+
+  // Get source labels.
+  const rawLabels = await clientSource.getLabels();
+
+  // Parsed labels.
+  const labels = rawLabels.map(({ color, name }) => ({ color, name }));
+
+  // Set the repository labels using the labels in the source repository.
+  await clientTarget.setLabels(labels);
+}

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -160,7 +160,7 @@ describe('Client', () => {
     });
   });
 
-  describe('updateLabels', () => {
+  describe('setLabels', () => {
     const labels = [
       {
         color: 'foo',
@@ -192,7 +192,7 @@ describe('Client', () => {
       client.createOrUpdateLabel = jest.fn(() => true);
       client.getLabels = jest.fn(() => currentLabels);
 
-      await client.updateLabels(labels);
+      await client.setLabels(labels);
 
       expect(client.deleteLabel).toHaveBeenCalledTimes(1);
       expect(client.deleteLabel).toHaveBeenCalledWith('quux');
@@ -203,7 +203,7 @@ describe('Client', () => {
       client.createOrUpdateLabel = jest.fn(() => true);
       client.getLabels = jest.fn(() => currentLabels);
 
-      await client.updateLabels(labels);
+      await client.setLabels(labels);
 
       expect(client.createOrUpdateLabel).toHaveBeenCalledTimes(labels.length);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,116 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { copyLabelsFromRepo, updateLabels } from '../src';
+import Client from '../src/client';
+import faker from 'faker';
+
+/**
+ * Jest mocks.
+ */
+
+jest.mock('../src/client');
+
+/**
+ * Test `index`.
+ */
+
+describe('index', () => {
+  let authenticate;
+  let getLabels;
+  let setLabels;
+
+  beforeEach(() => {
+    authenticate = jest.fn();
+    setLabels = jest.fn();
+    getLabels = jest.fn(() => [
+      {
+        color: 'foo',
+        link: 'http://foobar',
+        name: 'bar'
+      },
+      {
+        color: 'waldo',
+        link: 'http://waldo',
+        name: 'fred'
+      },
+      {
+        color: 'corge',
+        link: 'http://corge',
+        name: 'grault'
+      }
+    ]);
+
+    Client.mockClear();
+    Client.mockImplementation(() => ({
+      authenticate,
+      getLabels,
+      setLabels
+    }));
+  });
+
+  describe('updateLabels', () => {
+    it('should call `updateLabels` with given labels', async () => {
+      const expectedLabels = [
+        {
+          color: faker.commerce.color(),
+          name: faker.lorem.word()
+        },
+        {
+          color: faker.commerce.color(),
+          name: faker.lorem.word()
+        },
+        {
+          color: faker.commerce.color(),
+          name: faker.lorem.word()
+        }
+      ];
+
+      await updateLabels({
+        labels: expectedLabels,
+        owner: 'fred',
+        repo: 'waldo',
+        token: 'foobar'
+      });
+
+      expect(Client.mock.calls[0][0]).toEqual({ owner: 'fred', repo: 'waldo' });
+      expect(authenticate).toHaveBeenCalledWith('foobar');
+      expect(setLabels).toHaveBeenCalledWith(expectedLabels);
+    });
+  });
+
+  describe('copyLabelsFromRepo', () => {
+    it('should call `updateLabels` with the labels from the source repository', async () => {
+      await copyLabelsFromRepo({
+        sourceOwner: 'qux',
+        sourceRepo: 'corge',
+        targetOwner: 'fred',
+        targetRepo: 'waldo',
+        token: 'foobar'
+      });
+
+      const expectedLabels = [
+        {
+          color: 'foo',
+          name: 'bar'
+        },
+        {
+          color: 'waldo',
+          name: 'fred'
+        },
+        {
+          color: 'corge',
+          name: 'grault'
+        }
+      ];
+
+      expect(Client.mock.instances.length).toEqual(2);
+      expect(Client.mock.calls[0][0]).toEqual({ owner: 'qux', repo: 'corge' });
+      expect(Client.mock.calls[1][0]).toEqual({ owner: 'fred', repo: 'waldo' });
+      expect(getLabels).toHaveBeenCalledTimes(1);
+      expect(setLabels).toHaveBeenCalledWith(expectedLabels);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,6 +1297,10 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,6 +771,10 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -918,6 +922,14 @@ core-js@^2.4.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -1237,6 +1249,18 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -1337,7 +1361,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.1.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -1443,6 +1467,10 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -1786,6 +1814,10 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2232,16 +2264,21 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
-
-lodash.assign@^4.0.3, lodash.assign@^4.0.6:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -2257,11 +2294,24 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -2396,6 +2446,12 @@ normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
 npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -2472,6 +2528,14 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -2490,6 +2554,10 @@ output-file-sync@^1.1.0:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
   version "1.1.0"
@@ -2542,6 +2610,10 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
@@ -2553,6 +2625,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -2614,6 +2692,10 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2649,6 +2731,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -2656,6 +2745,14 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.2.9"
@@ -2881,6 +2978,16 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shelljs@^0.7.5:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
@@ -3030,6 +3137,10 @@ strip-bom@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -3244,7 +3355,11 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.12:
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+
+which@^1.2.12, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -3259,10 +3374,6 @@ wide-align@^1.1.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-
-window-size@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
 wordwrap@0.0.2:
   version "0.0.2"
@@ -3312,12 +3423,9 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yargs-parser@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
-  dependencies:
-    camelcase "^3.0.0"
-    lodash.assign "^4.0.6"
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs-parser@^5.0.0:
   version "5.0.0"
@@ -3325,24 +3433,11 @@ yargs-parser@^5.0.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@^4.2.0:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    lodash.assign "^4.0.3"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^1.0.1"
-    which-module "^1.0.0"
-    window-size "^0.2.0"
-    y18n "^3.2.1"
-    yargs-parser "^2.4.1"
+    camelcase "^4.1.0"
 
 yargs@^7.0.2:
   version "7.1.0"
@@ -3361,6 +3456,24 @@ yargs@^7.0.2:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This PR adds the `copy` command which is intent to copy all labels from a repository and set the labels on the target repository.

To achieve this it was necessary to refactor the `bin/labels` which now accepts both `update` (default) and `copy` commands.

A source code refactor was also in place to properly organize the commands code.

