### PR TITLE
Update program options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn global add ghlabels
 You can provide options as arguments or leave then blank and they will be prompted.
 
 ```sh
-ghlabels --owner foo --repo bar --token foobar --configFile ./path/somefile
+ghlabels --repository foo/bar --token foobar --file ./path/somefile
 ```
 
 Note: As an alternative you can provide options as enviroment variables (e.g. GITHUB_LABELS_TOKEN).
@@ -36,13 +36,13 @@ Note: As an alternative you can provide options as enviroment variables (e.g. GI
 ### Copy from another repo
 
 ```sh
-ghlabels copy --sourceOwner seegno --sourceRepo github-labels --targetOwner foo --targetRepo bar --token foobar
+ghlabels copy --source seegno/github-labels --target foo/bar --token foobar
 ```
 
 ### List
 
 ```sh
-ghlabels list --owner seegno --repo github-labels
+ghlabels list --repository seegno/github-labels
 ```
 
 ### Client
@@ -54,24 +54,20 @@ import { copyLabelsFromRepo, listLabels, updateLabels } from 'ghlabels';
 
 // Example of copying labels from a source repo.
 copyLabelsFromRepo({
-  owner: 'foo',
-  repo: 'bar',
+  source: 'seegno/github-labels'
+  target: 'foo/bar',
   token: 'foobar'
 });
 
 // Example of listing all labels from a repo.
 listLabels({
-  owner: 'seegno',
-  repo: 'github-labels',
+  repository: 'seegno/github-labels',
   token: 'foobar'
 });
 
 // Example of updating all labels from a repo.
 updateLabels({
-  sourceOwner: 'seegno',
-  sourceRepo: 'github-labels',
-  targetOwner: 'foo',
-  targetRepo: 'bar',
+  repository: 'foo/bar',
   token: 'foobar'
 });
 ```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "bluebird": "^3.3.1",
     "fs": "^0.0.2",
-    "github": "^9.2.0",
+    "github": "^11.0.0",
     "inquirer": "^3.0.6",
     "lodash": "^4.3.0",
     "prettyjson": "^1.1.3",

--- a/src/commands/copy-from-repo-command.js
+++ b/src/commands/copy-from-repo-command.js
@@ -14,12 +14,10 @@ import prettyjson from 'prettyjson';
 
 export function copyFromRepoConfig(yargs) {
   yargs
-    .option('sourceOwner', { demand: false, describe: 'Source repository owner', type: 'string' })
-    .option('sourceRepo', { demand: false, describe: 'Source repository name', type: 'string' })
-    .option('targetOwner', { demand: false, describe: 'Target repository owner', type: 'string' })
-    .option('targetRepo', { demand: false, describe: 'Target repository name', type: 'string' })
+    .option('source', { demand: false, describe: 'Source repository name (ex. seegno/github-labels)', type: 'string' })
+    .option('target', { demand: false, describe: 'Target repository name (ex. seegno/github-labels)', type: 'string' })
     .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
-    .example('$0 --owner foo --repo bar --sourceOwner qux --sourceRepo corge --token foobar');
+    .example('$0 --source foo/bar --target qux/corge --token foobar');
 }
 
 /**
@@ -28,24 +26,14 @@ export function copyFromRepoConfig(yargs) {
 
 export async function copyFromRepo(args) {
   const questions = {
-    sourceOwner: {
-      message: 'What is the source owner name?',
-      name: 'sourceOwner',
+    source: {
+      message: 'What is the source repository name? (ex. seegno/github-labels)',
+      name: 'source',
       validate: input => !!input
     },
-    sourceRepo: {
-      message: 'What is the source repository name?',
-      name: 'sourceRepo',
-      validate: input => !!input
-    },
-    targetOwner: {
-      message: 'What is the target owner name?',
-      name: 'targetOwner',
-      validate: input => !!input
-    },
-    targetRepo: {
-      message: 'What is the target repository name?',
-      name: 'targetRepo',
+    target: {
+      message: 'What is the target repository name? (ex. seegno/github-labels)',
+      name: 'target',
       validate: input => !!input
     },
     token: {
@@ -61,7 +49,11 @@ export async function copyFromRepo(args) {
   console.log('Copying labels from repo...'); // eslint-disable-line no-console
   console.log(prettyjson.render(pick(options, keys(pickBy(questions))))); // eslint-disable-line no-console
 
-  await copyLabelsFromRepo(options);
+  try {
+    await copyLabelsFromRepo(options);
 
-  return console.log('Copy completed!'); // eslint-disable-line no-console
+    console.log('Copy completed!'); // eslint-disable-line no-console
+  } catch (e) {
+    console.error(e.message); // eslint-disable-line no-console
+  }
 }

--- a/src/commands/list-command.js
+++ b/src/commands/list-command.js
@@ -14,10 +14,9 @@ import prettyjson from 'prettyjson';
 
 export function listConfig(yargs) {
   yargs
-    .option('owner', { demand: false, describe: 'Repository owner', type: 'string' })
-    .option('repo', { demand: false, describe: 'Repository name', type: 'string' })
+    .option('repository', { demand: false, describe: 'Repository name (ex. seegno/github-labels)', type: 'string' })
     .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
-    .example('$0 --repo foo --token bar --configFile ./path/somefile');
+    .example('$0 --repository foo/bar --token');
 }
 
 /**
@@ -26,14 +25,9 @@ export function listConfig(yargs) {
 
 export async function list(args) {
   const questions = {
-    owner: {
-      message: 'What is the owner name?',
-      name: 'owner',
-      validate: input => !!input
-    },
-    repo: {
-      message: 'What is the repository name?',
-      name: 'repo',
+    repository: {
+      message: 'What is the repository name? (ex. seegno/github-labels)',
+      name: 'repository',
       validate: input => !!input
     },
     token: {

--- a/src/commands/update-command.js
+++ b/src/commands/update-command.js
@@ -22,11 +22,10 @@ const readFileAsync = Promise.promisify(readFile);
 
 export function updateConfig(yargs) {
   yargs
-    .option('configFile', { demand: false, describe: 'Configuration file', type: 'string' })
-    .option('owner', { demand: false, describe: 'Repository owner', type: 'string' })
-    .option('repo', { demand: false, describe: 'Repository name', type: 'string' })
+    .option('file', { demand: false, describe: 'Configuration file', type: 'string' })
+    .option('repository', { demand: false, describe: 'Repository name (ex. seegno/github-labels)', type: 'string' })
     .option('token', { demand: true, describe: 'GitHub authentication token', type: 'string' })
-    .example('$0 --owner foo --repo bar --token foobar --configFile ./path/somefile');
+    .example('$0 --repository foo/bar --token foobar --file ./path/somefile');
 }
 
 /**
@@ -35,19 +34,14 @@ export function updateConfig(yargs) {
 
 export async function update(args) {
   const questions = {
-    configFile: {
+    file: {
       message: 'What is the configuration file path?',
-      name: 'configFile',
+      name: 'file',
       validate: input => !!input
     },
-    owner: {
-      message: 'What is the owner name?',
-      name: 'owner',
-      validate: input => !!input
-    },
-    repo: {
-      message: 'What is the repository name?',
-      name: 'repo',
+    repository: {
+      message: 'What is the repository name? (ex. seegno/github-labels)',
+      name: 'repository',
       validate: input => !!input
     },
     token: {
@@ -63,11 +57,15 @@ export async function update(args) {
   console.log('Updating labels...'); // eslint-disable-line no-console
   console.log(prettyjson.render(pick(options, keys(pickBy(questions))))); // eslint-disable-line no-console
 
-  // Retrieve labels from file.
-  const content = await readFileAsync(get(options, 'configFile'), 'utf8');
-  const labels = JSON.parse(content);
+  try {
+    // Retrieve labels from file.
+    const content = await readFileAsync(get(options, 'file'), 'utf8');
+    const labels = JSON.parse(content);
 
-  await updateLabels({ ...options, labels });
+    await updateLabels({ ...options, labels });
 
-  return console.log('Update completed!'); // eslint-disable-line no-console
+    console.log('Update completed!'); // eslint-disable-line no-console
+  } catch (e) {
+    console.log(e.message); // eslint-disable-line no-console
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,16 +10,13 @@ import Client from 'client';
  */
 
 export async function listLabels(options) {
-  const { owner, repo, token } = options;
+  const { repository, token } = options;
 
   // Instantiate client.
-  const client = new Client({ owner, repo });
-
-  // Authenticate user.
-  client.authenticate(token);
+  const client = new Client({ token });
 
   // Get source labels.
-  const labels = await client.getLabels();
+  const labels = await client.getLabels(repository);
 
   // Parsed labels.
   return labels.map(({ color, name }) => ({ color, name }));
@@ -30,16 +27,13 @@ export async function listLabels(options) {
  */
 
 export async function updateLabels(options) {
-  const { owner, repo, token, labels } = options;
+  const { repository, token, labels } = options;
 
   // Instantiate client.
-  const client = new Client({ owner, repo });
-
-  // Authenticate user.
-  client.authenticate(token);
+  const client = new Client({ token });
 
   // Set the repository labels using the labels in the configuration file.
-  await client.setLabels(labels);
+  await client.setLabels(repository, labels);
 }
 
 /**
@@ -47,22 +41,17 @@ export async function updateLabels(options) {
  */
 
 export async function copyLabelsFromRepo(options) {
-  const { sourceOwner, sourceRepo, targetOwner, targetRepo, token } = options;
+  const { source, target, token } = options;
 
   // Instantiate clients.
-  const clientSource = new Client({ owner: sourceOwner, repo: sourceRepo });
-  const clientTarget = new Client({ owner: targetOwner, repo: targetRepo });
-
-  // Authenticate user.
-  clientSource.authenticate(token);
-  clientTarget.authenticate(token);
+  const client = new Client({ token });
 
   // Get source labels.
-  const rawLabels = await clientSource.getLabels();
+  const rawLabels = await client.getLabels(source);
 
   // Parsed labels.
   const labels = rawLabels.map(({ color, name }) => ({ color, name }));
 
   // Set the repository labels using the labels in the source repository.
-  await clientTarget.setLabels(labels);
+  await client.setLabels(target, labels);
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -8,42 +8,77 @@ import Github from 'github';
 import HttpError from 'standard-http-error';
 
 /**
+ * Jest mocks.
+ */
+
+jest.mock('github');
+
+/**
  * Test `Client`.
  */
 
 describe('Client', () => {
-  const defaultOptions = { owner: 'fred', repo: 'waldo' };
+  const defaultOptions = { token: 'foobiz' };
+  const repository = 'corge/waldo';
+  const repositoryOptions = { owner: 'corge', repo: 'waldo' };
+  let authenticate;
   let client;
+  let createLabel;
+  let deleteLabel;
+  let getLabel;
+  let getLabels;
+  let issues;
+  let updateLabels;
 
   beforeEach(() => {
+    authenticate = jest.fn();
+    createLabel = jest.fn();
+    deleteLabel = jest.fn();
+    getLabel = jest.fn();
+    getLabels = jest.fn();
+    updateLabels = jest.fn();
+
+    issues = {
+      createLabel,
+      deleteLabel,
+      getLabel,
+      getLabels,
+      updateLabels
+    };
+
+    Github.mockImplementation(() => ({ authenticate, issues }));
+
     client = new Client(defaultOptions);
   });
 
   describe('constructor', () => {
     it('should create an instance of `client` with given arguments', () => {
-      expect(client.owner).toBe('fred');
-      expect(client.repo).toBe('waldo');
-      expect(client.github).toBeInstanceOf(Github);
+      expect(client.github).toEqual({ authenticate, issues });
     });
-  });
 
-  describe('authenticate', () => {
     it('should call `github.authenticate` with given token and type as `oauth`', () => {
-      client.github.authenticate = jest.fn(() => true);
-      client.authenticate('foobiz');
-
       expect(client.github.authenticate).toHaveBeenCalledTimes(1);
       expect(client.github.authenticate).toHaveBeenCalledWith({ token: 'foobiz', type: 'oauth' });
     });
   });
 
   describe('createLabel', () => {
-    it('should call `github.issues.createLabelAsync` with default options and given `name` and `color`', () => {
-      client.github.issues.createLabelAsync = jest.fn(() => true);
-      client.createLabel('foo', 'bar');
+    it('should throw an error with `Malformed repository option` message if given `repository` have an invalid format', async () => {
+      try {
+        await client.createLabel('foobar');
 
-      expect(client.github.issues.createLabelAsync).toHaveBeenCalledTimes(1);
-      expect(client.github.issues.createLabelAsync).toHaveBeenCalledWith({ ...defaultOptions, color: 'bar', name: 'foo' });
+        fail();
+      } catch (e) {
+        expect(e.message).toBe('Malformed repository option');
+      }
+    });
+
+    it('should call `github.issues.createLabel` with repository options and given `name` and `color`', () => {
+      client.github.issues.createLabel = jest.fn(() => true);
+      client.createLabel(repository, 'foo', 'bar');
+
+      expect(client.github.issues.createLabel).toHaveBeenCalledTimes(1);
+      expect(client.github.issues.createLabel).toHaveBeenCalledWith({ ...repositoryOptions, color: 'bar', name: 'foo' });
     });
   });
 
@@ -52,7 +87,7 @@ describe('Client', () => {
       client.getLabel = jest.fn(() => { throw new Error('foobar'); });
 
       try {
-        await client.createOrUpdateLabel();
+        await client.createOrUpdateLabel(repository);
 
         fail();
       } catch (e) {
@@ -64,7 +99,7 @@ describe('Client', () => {
       client.getLabel = jest.fn(() => { throw new HttpError(100); });
 
       try {
-        await client.createOrUpdateLabel();
+        await client.createOrUpdateLabel(repository);
 
         fail();
       } catch (e) {
@@ -72,91 +107,131 @@ describe('Client', () => {
       }
     });
 
-    it('should call `createLabel` with given `name` and `color` if `getLabel` throws an error with code 404', async () => {
+    it('should call `createLabel` with given `repository`, `name` and `color` if `getLabel` throws an error with code 404', async () => {
       client.getLabel = jest.fn(() => { throw new HttpError(404); });
       client.updateLabel = jest.fn();
       client.createLabel = jest.fn(() => Promise.resolve('foobiz'));
 
-      const response = await client.createOrUpdateLabel('foo', 'bar');
+      const response = await client.createOrUpdateLabel(repository, 'foo', 'bar');
 
       expect(response).toBe('foobiz');
       expect(client.updateLabel).toHaveBeenCalledTimes(0);
       expect(client.createLabel).toHaveBeenCalledTimes(1);
-      expect(client.createLabel).toHaveBeenCalledWith('foo', 'bar');
+      expect(client.createLabel).toHaveBeenCalledWith(repository, 'foo', 'bar');
     });
 
-    it('should call `updateLabel` with given `name` and `color` if `getLabel` returns a label', async () => {
+    it('should call `updateLabel` with given `repository`, `name` and `color` if `getLabel` returns a label', async () => {
       client.getLabel = jest.fn(() => true);
       client.createLabel = jest.fn();
       client.updateLabel = jest.fn(() => Promise.resolve('foobiz'));
 
-      const response = await client.createOrUpdateLabel('foo', 'bar');
+      const response = await client.createOrUpdateLabel(repository, 'foo', 'bar');
 
       expect(response).toBe('foobiz');
       expect(client.createLabel).toHaveBeenCalledTimes(0);
       expect(client.updateLabel).toHaveBeenCalledTimes(1);
-      expect(client.updateLabel).toHaveBeenCalledWith('foo', 'bar');
+      expect(client.updateLabel).toHaveBeenCalledWith(repository, 'foo', 'bar');
     });
 
-    it('should call `createLabel` with given `name` and `color` if `getLabel` does not returns a label', async () => {
+    it('should call `createLabel` with given `repository`, `name` and `color` if `getLabel` does not returns a label', async () => {
       client.getLabel = jest.fn(() => false);
       client.updateLabel = jest.fn();
       client.createLabel = jest.fn(() => Promise.resolve('foobiz'));
 
-      const response = await client.createOrUpdateLabel('foo', 'bar');
+      const response = await client.createOrUpdateLabel(repository, 'foo', 'bar');
 
       expect(response).toBe('foobiz');
       expect(client.updateLabel).toHaveBeenCalledTimes(0);
       expect(client.createLabel).toHaveBeenCalledTimes(1);
-      expect(client.createLabel).toHaveBeenCalledWith('foo', 'bar');
+      expect(client.createLabel).toHaveBeenCalledWith(repository, 'foo', 'bar');
     });
   });
 
   describe('deleteLabel', () => {
-    it('should call `github.issues.deleteLabelAsync` with default options and given `name` and `color`', () => {
-      client.github.issues.deleteLabelAsync = jest.fn(() => true);
-      client.deleteLabel('foobar');
+    it('should throw an error with `Malformed repository option` message if given `repository` have an invalid format', async () => {
+      try {
+        await client.deleteLabel('foobar');
 
-      expect(client.github.issues.deleteLabelAsync).toHaveBeenCalledTimes(1);
-      expect(client.github.issues.deleteLabelAsync).toHaveBeenCalledWith({ ...defaultOptions, name: 'foobar' });
+        fail();
+      } catch (e) {
+        expect(e.message).toBe('Malformed repository option');
+      }
+    });
+
+    it('should call `github.issues.deleteLabel` with repository options and given `name` and `color`', () => {
+      client.github.issues.deleteLabel = jest.fn(() => true);
+      client.deleteLabel(repository, 'foobar');
+
+      expect(client.github.issues.deleteLabel).toHaveBeenCalledTimes(1);
+      expect(client.github.issues.deleteLabel).toHaveBeenCalledWith({ ...repositoryOptions, name: 'foobar' });
     });
   });
 
   describe('getLabels', () => {
-    it('should call `github.issues.getLabelsAsync` with default options', () => {
-      client.github.issues.getLabelsAsync = jest.fn(() => true);
-      client.getLabels('foobar');
+    it('should throw an error with `Malformed repository option` message if given `repository` have an invalid format', async () => {
+      try {
+        await client.getLabels('foobar');
 
-      expect(client.github.issues.getLabelsAsync).toHaveBeenCalledTimes(1);
-      expect(client.github.issues.getLabelsAsync).toHaveBeenCalledWith({ ...defaultOptions });
+        fail();
+      } catch (e) {
+        expect(e.message).toBe('Malformed repository option');
+      }
     });
 
-    it('should return the data property from the result of the call `github.issues.getLabelsAsync`', () => {
-      client.github.issues.getLabelsAsync = jest.fn(() => Promise.resolve({ data: 'foobar' }));
+    it('should call `github.issues.getLabels` with repository options', () => {
+      client.github.issues.getLabels = jest.fn(() => true);
+      client.getLabels(repository, 'foobar');
 
-      return client.getLabels().then(label => {
+      expect(client.github.issues.getLabels).toHaveBeenCalledTimes(1);
+      expect(client.github.issues.getLabels).toHaveBeenCalledWith({ ...repositoryOptions });
+    });
+
+    it('should return the data property from the result of the call `github.issues.getLabels`', () => {
+      client.github.issues.getLabels = jest.fn(() => Promise.resolve({ data: 'foobar' }));
+
+      return client.getLabels(repository).then(label => {
         expect(label).toBe('foobar');
       });
     });
   });
 
   describe('getLabel', () => {
-    it('should call `github.issues.getLabelAsync` with default options and given `name` and `color`', () => {
-      client.github.issues.getLabelAsync = jest.fn(() => true);
-      client.getLabel('foobar');
+    it('should throw an error with `Malformed repository option` message if given `repository` have an invalid format', async () => {
+      try {
+        await client.getLabel('foobar');
 
-      expect(client.github.issues.getLabelAsync).toHaveBeenCalledTimes(1);
-      expect(client.github.issues.getLabelAsync).toHaveBeenCalledWith({ ...defaultOptions, name: 'foobar' });
+        fail();
+      } catch (e) {
+        expect(e.message).toBe('Malformed repository option');
+      }
+    });
+
+    it('should call `github.issues.getLabel` with repository options and given `name` and `color`', () => {
+      client.github.issues.getLabel = jest.fn(() => true);
+      client.getLabel(repository, 'foobar');
+
+      expect(client.github.issues.getLabel).toHaveBeenCalledTimes(1);
+      expect(client.github.issues.getLabel).toHaveBeenCalledWith({ ...repositoryOptions, name: 'foobar' });
     });
   });
 
   describe('updateLabel', () => {
-    it('should call `github.issues.updateLabelAsync` with default options and given `name` and `color`', () => {
-      client.github.issues.updateLabelAsync = jest.fn(() => true);
-      client.updateLabel('foo', 'bar');
+    it('should throw an error with `Malformed repository option` message if given `repository` have an invalid format', async () => {
+      try {
+        await client.getLabel('foobar');
 
-      expect(client.github.issues.updateLabelAsync).toHaveBeenCalledTimes(1);
-      expect(client.github.issues.updateLabelAsync).toHaveBeenCalledWith({ ...defaultOptions, color: 'bar', name: 'foo', oldname: 'foo' });
+        fail();
+      } catch (e) {
+        expect(e.message).toBe('Malformed repository option');
+      }
+    });
+
+    it('should call `github.issues.updateLabel` with repository options and given `name` and `color`', () => {
+      client.github.issues.updateLabel = jest.fn(() => true);
+      client.updateLabel(repository, 'foo', 'bar');
+
+      expect(client.github.issues.updateLabel).toHaveBeenCalledTimes(1);
+      expect(client.github.issues.updateLabel).toHaveBeenCalledWith({ ...repositoryOptions, color: 'bar', name: 'foo', oldname: 'foo' });
     });
   });
 
@@ -192,10 +267,10 @@ describe('Client', () => {
       client.createOrUpdateLabel = jest.fn(() => true);
       client.getLabels = jest.fn(() => currentLabels);
 
-      await client.setLabels(labels);
+      await client.setLabels(repository, labels);
 
       expect(client.deleteLabel).toHaveBeenCalledTimes(1);
-      expect(client.deleteLabel).toHaveBeenCalledWith('quux');
+      expect(client.deleteLabel).toHaveBeenCalledWith(repository, 'quux');
     });
 
     it('should call `createOrUpdateLabel` for all labels', async () => {
@@ -203,12 +278,12 @@ describe('Client', () => {
       client.createOrUpdateLabel = jest.fn(() => true);
       client.getLabels = jest.fn(() => currentLabels);
 
-      await client.setLabels(labels);
+      await client.setLabels(repository, labels);
 
       expect(client.createOrUpdateLabel).toHaveBeenCalledTimes(labels.length);
 
       labels.forEach(({ color, name }) => {
-        expect(client.createOrUpdateLabel).toHaveBeenCalledWith(name, color);
+        expect(client.createOrUpdateLabel).toHaveBeenCalledWith(repository, name, color);
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,12 +18,10 @@ jest.mock('../src/client');
  */
 
 describe('index', () => {
-  let authenticate;
   let getLabels;
   let setLabels;
 
   beforeEach(() => {
-    authenticate = jest.fn();
     setLabels = jest.fn();
     getLabels = jest.fn(() => [
       {
@@ -45,7 +43,6 @@ describe('index', () => {
 
     Client.mockClear();
     Client.mockImplementation(() => ({
-      authenticate,
       getLabels,
       setLabels
     }));
@@ -54,10 +51,8 @@ describe('index', () => {
   describe('copyLabelsFromRepo', () => {
     it('should call `client.setLabels` with the labels from the source repository', async () => {
       await copyLabelsFromRepo({
-        sourceOwner: 'qux',
-        sourceRepo: 'corge',
-        targetOwner: 'fred',
-        targetRepo: 'waldo',
+        source: 'corge',
+        target: 'waldo',
         token: 'foobar'
       });
 
@@ -76,11 +71,12 @@ describe('index', () => {
         }
       ];
 
-      expect(Client.mock.instances.length).toEqual(2);
-      expect(Client.mock.calls[0][0]).toEqual({ owner: 'qux', repo: 'corge' });
-      expect(Client.mock.calls[1][0]).toEqual({ owner: 'fred', repo: 'waldo' });
+      expect(Client.mock.instances.length).toEqual(1);
+      expect(Client.mock.calls[0][0]).toEqual({ token: 'foobar' });
       expect(getLabels).toHaveBeenCalledTimes(1);
-      expect(setLabels).toHaveBeenCalledWith(expectedLabels);
+      expect(getLabels).toHaveBeenCalledWith('corge');
+      expect(setLabels).toHaveBeenCalledTimes(1);
+      expect(setLabels).toHaveBeenCalledWith('waldo', expectedLabels);
     });
   });
 
@@ -102,14 +98,14 @@ describe('index', () => {
       ];
 
       const result = await listLabels({
-        owner: 'fred',
-        repo: 'waldo',
+        repository: 'waldo',
         token: 'foobar'
       });
 
-      expect(Client.mock.calls[0][0]).toEqual({ owner: 'fred', repo: 'waldo' });
-      expect(authenticate).toHaveBeenCalledWith('foobar');
+      expect(Client.mock.instances.length).toEqual(1);
+      expect(Client.mock.calls[0][0]).toEqual({ token: 'foobar' });
       expect(getLabels).toHaveBeenCalledTimes(1);
+      expect(getLabels).toHaveBeenCalledWith('waldo');
       expect(result).toEqual(expectedLabels);
     });
   });
@@ -133,14 +129,14 @@ describe('index', () => {
 
       await updateLabels({
         labels,
-        owner: 'fred',
-        repo: 'waldo',
+        repository: 'waldo',
         token: 'foobar'
       });
 
-      expect(Client.mock.calls[0][0]).toEqual({ owner: 'fred', repo: 'waldo' });
-      expect(authenticate).toHaveBeenCalledWith('foobar');
-      expect(setLabels).toHaveBeenCalledWith(labels);
+      expect(Client.mock.instances.length).toEqual(1);
+      expect(Client.mock.calls[0][0]).toEqual({ token: 'foobar' });
+      expect(setLabels).toHaveBeenCalledTimes(1);
+      expect(setLabels).toHaveBeenCalledWith('waldo', labels);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,9 +1561,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/github/-/github-9.2.0.tgz#8a886dc40dd63636707dcaf99df3df26c59f16fc"
+github@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/github/-/github-11.0.0.tgz#edb32df5efb33cad004ebf0bdd2a4b30bb63a854"
   dependencies:
     follow-redirects "0.0.7"
     https-proxy-agent "^1.0.0"


### PR DESCRIPTION
This PR updates options to receive only a composed repository (e.g seegno/github-labels) instead of two options (owner and repo name).

It also updates configuration file name option to `file`.

Also in this PR github dependency was updated to version `11.0.0` and README examples. 

Examples: 

Before:
```
ghlabels --owner foo --repo bar --token foobar --configFile ./path/somefile
```

Now:
```
ghlabels --repository foo/bar --token foobar --file ./path/somefile
```