### PR TITLE
Fix lint-staged configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   "lint-staged": {
     "{src,test}/**/*.js": [
       "eslint",
-      "git add",
       "jest --findRelatedTests --forceExit"
     ]
   }


### PR DESCRIPTION
This PR fixes lint-staged configuration by removing `git add` instruction that was adding the file even if there were some chunks that weren't staged.